### PR TITLE
add credentials file

### DIFF
--- a/Plantomation/.gitignore
+++ b/Plantomation/.gitignore
@@ -3,3 +3,5 @@
 .vscode/c_cpp_properties.json
 .vscode/launch.json
 .vscode/ipch
+credentials.h
+

--- a/Plantomation/src/main.cpp
+++ b/Plantomation/src/main.cpp
@@ -15,8 +15,12 @@
 
 #include "sites.h"
 
+#if __has_include("credentials.h")
+#include "credentials.h"
+#else
 const char *ssid = "XXX";
 const char *password = "XXX";
+#endif
 
 String hostname = "ESP32-Test";
 


### PR DESCRIPTION
remove ssid and password from code, use it only if no credentials file exits.
The credentials should be placed into a file named credentials.h with the content:

```
const char *ssid = "XXX";
const char *password = "XXX";
```

the credentials.h is in gitignore and is not pushed to the remote server.
